### PR TITLE
Remove qitt.ru

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -194,7 +194,6 @@ prodvigator.ua
 prointer.net.ua
 promoforum.ru
 psa48.ru
-qitt.ru
 qwesa.ru
 ranksonic.info
 ranksonic.org


### PR DESCRIPTION
I have been contacted by the webmaster of qitt.ru who was surprised to find his website here (saying that it had nothing to do with referrer spam), and asked it to be removed from the list. Since it was added in a "bulk" pull request, and since (IMO) the priority is to avoid mistakes (that could hurt real businesses, and that lower the credibility of this list), I'll be applying it ASAP.

I think it's a good time for us to move to a "peer-review-only" merge, i.e. merge only websites that have been reported/approved by at least 2 people. We should also document in the README that it's better to add one site at a time in pull request, we should avoid "bulk changes" because they are harder to validate.