### PR TITLE
Added chinese-amezon.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -60,6 +60,7 @@ cartechnic.ru
 cenokos.ru
 cenoval.ru
 cezartabac.ro
+chinese-amezon.com
 cityadspix.com
 ci.ua
 civilwartheater.com


### PR DESCRIPTION
I was analyzing my unfiltered Google Analytics view. Every spam referrer was already on the list except this one (chinese-amezon.com).

<img width="498" alt="screen shot 2015-08-06 at 12 33 15 pm" src="https://cloud.githubusercontent.com/assets/2852617/9121531/a96e8e4a-3c37-11e5-8979-24a219ce4332.png">
