### PR TITLE
Add seoanalyses.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -213,6 +213,7 @@ screentoolkit.com
 search-error.com
 semalt.com
 semaltmedia.com
+seoanalyses.com
 seoexperimenty.ru
 seopub.net
 seo-smm.kz


### PR DESCRIPTION
`seoanalyses.com` was reported in separate "bulk" pull requests, so I'm adding it in a single commit.

It was reported in #73 and #94. Another confirmation that this is a spammer domain can be found at http://observingreality.com/?p=157