### PR TITLE
Added get-free-social-traffic.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -111,6 +111,7 @@ freewhatsappload.com
 fsalas.com
 generalporn.org
 germes-trans.com
+get-free-social-traffic.com
 get-free-traffic-now.com
 ghazel.ru
 girlporn.ru


### PR DESCRIPTION
I have seen this url pop up is some servers that I maintain, it is quite obviously a referrer spam domain, similar to get-free-traffic-now.com