### PR TITLE
get-free-social-traffic.com added

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -111,6 +111,7 @@ freewhatsappload.com
 fsalas.com
 generalporn.org
 germes-trans.com
+get-free-social-traffic.com
 get-free-traffic-now.com
 ghazel.ru
 girlporn.ru


### PR DESCRIPTION
Nearly 30% of new traffic on one of our sites, 90% bounce rate, redirects to the same old sharebutton.to spam site that's been around for ages.