### PR TITLE
Add alfa9.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -13,6 +13,7 @@ adviceforum.info
 affordablewebsitesandmobileapps.com
 afora.ru
 akuhni.by
+alfa9.com
 allknow.info
 allnews.md
 allwomen.info


### PR DESCRIPTION
I got this very surprising graph for the `alfa9.com` domain only:

<img width="1003" alt="capture d ecran 2015-09-10 a 11 00 08" src="https://cloud.githubusercontent.com/assets/720328/9784422/6927e0a4-57ab-11e5-9f7c-4c51fe79fba3.png">

It completely exploded my stats (10 000 sessions). All these are 1 page/session, 100% new visitors, 100% bounce, all coming from the home page of the domain… Obvious spam I guess.

I didn't get that on my Piwik stats, I guess alfa9.com spammed Google's API directly.
