### PR TITLE
Added copyrightclaims.org

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -69,6 +69,7 @@ coderstate.com
 codysbbq.com
 conciergegroup.org
 connectikastudio.com
+copyrightclaims.org
 cubook.supernew.org
 customsua.com.ua
 dailyrank.net


### PR DESCRIPTION
Other pepople confiming this is spam referreal:
http://www.ohow.co/remove-copyrightclaims-org-referral-spam-google-analytics/
http://www.besttechtips.org/instructions-to-remove-copyrightclaims-org/
etc..