### PR TITLE
Add wordpress-crew.net

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -277,6 +277,7 @@ webmonetizer.net
 websites-reviews.com
 websocial.me
 wmasterlead.com
+wordpress-crew.net
 ykecwqlixx.ru
 youporn-forum.ga
 youporn-forum.uni.me


### PR DESCRIPTION
The referring page does not mention my urls anywhere, they're only advertising their services.

[Screenshot](https://d.pr/i/1fIOx)