### PR TITLE
Remove dead domains

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -21,7 +21,6 @@ alpharma.net
 altermix.ua
 amt-k.ru
 anal-acrobats.hol.es
-anapa-inns.ru
 android-style.com
 anticrawler.org
 arendakvartir.kz
@@ -64,7 +63,6 @@ cartechnic.ru
 cenokos.ru
 cenoval.ru
 cezartabac.ro
-chinese-amezon.com
 cityadspix.com
 ci.ua
 civilwartheater.com
@@ -131,7 +129,6 @@ goodprotein.ru
 googlsucks.com
 guardlink.org
 handicapvantoday.com
-hongfanji.com
 howopen.ru
 howtostopreferralspam.eu
 hulfingtonpost.com
@@ -182,7 +179,6 @@ mobilemedia.md
 moyakuhnia.ru
 msk.afora.ru
 muscle-factory.com.ua
-myftpupload.com
 niki-mlt.ru
 novosti-hi-tech.ru
 online-hit.info
@@ -247,12 +243,10 @@ sitevaluation.org
 sledstvie-veli.net
 slftsdybbg.ru
 slkrm.ru
-snip.to
 soaksoak.ru
 social-buttons.com
 socialseet.ru
 sohoindia.net
-solnplast.ru
 sosdepotdebilan.com
 spb.afora.ru
 spravka130.ru

--- a/spammers.txt
+++ b/spammers.txt
@@ -246,7 +246,6 @@ slkrm.ru
 soaksoak.ru
 social-buttons.com
 socialseet.ru
-sohoindia.net
 sosdepotdebilan.com
 spb.afora.ru
 spravka130.ru


### PR DESCRIPTION
See #135.

I identify domain as dead if [major DNS services](https://github.com/desbma/referer-spam-domains-blacklist/blob/2aa38dbaa6a7ccf1f23cb6b10b95f88c1db60c0c/remove-dead-domains.py#L13-L17)  have no DNS A entry for this domain.
If all DNS servers don't return the same results, I consider the domain as dead only if both TCP port 80 and 443 are not open or if the resolved IP is not reachable.