### PR TITLE
Adds zebradudka.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -290,6 +290,7 @@ youporn-forum.uni.me
 youporn-ru.com
 yourserverisdown.com
 zastroyka.org
+zebradudka.com
 грузоподъемные-машины.рф
 наркомания.лечениенаркомании.com
 непереводимая.рф


### PR DESCRIPTION
hi everyone, 
i'm submitting a bunch of referrer spam url's hitting our server, such as ...
zebradudka.com

i've been blocking them individually like this in my .htaccess

RewriteCond %{HTTP_REFERER} zebradudka.com [NC]
RewriteRule .\* - [F]

but i am not sure if this is the best way to do this, b great if someone know a better way to do it if you could let me know.  one thing we are noticing is that for  a number of these sites they are actually from the same ip address

i am also not sure how to represent the url's in .htaccess if they include www in front of the url - if anyone knows how to do this i'd love to find out - we have been inundated and the server is being limited
zod
