### PR TITLE
Add adf.ly

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -7,6 +7,7 @@
 7makemoneyonline.com
 acads.net
 adcash.com
+adf.ly
 adspart.com
 adventureparkcostarica.com
 adviceforum.info


### PR DESCRIPTION
Over 80% of traffic at a site in one day came from here. 100% bounce rate. The domain itself is used to buy/sell link referrals. Oddly this Libyan domain is registered in the UK:
Registrant:
   x19 Limited
   Ian Donovan
   27 Old Gloucester Street
   London
   United Kingdom
   Zip/Postal code: WC1N 3AX
   contact@x19.biz