### PR TITLE
Add hosting-tracker.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -134,6 +134,7 @@ googlsucks.com
 guardlink.org
 handicapvantoday.com
 hongfanji.com
+hosting-tracker.com
 howopen.ru
 howtostopreferralspam.eu
 hulfingtonpost.com


### PR DESCRIPTION
Ghost referral spam based on GA and web server logs