### PR TITLE
Add fast-wordpress-start.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -108,6 +108,7 @@ euromasterclass.ru
 europages.com.ru
 eurosamodelki.ru
 event-tracking.com
+fast-wordpress-start.com
 fbdownloader.com
 floating-share-buttons.com
 forex-procto.ru


### PR DESCRIPTION
Found in some of our clients' accounts. Already filtering this.