### PR TITLE
Add googlemare.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -131,6 +131,7 @@ gkvector.ru
 glavprofit.ru
 gobongo.info
 goodprotein.ru
+googlemare.com
 googlsucks.com
 guardlink.org
 handicapvantoday.com


### PR DESCRIPTION
Found in few Clients' accounts.
In GA forces hostname to google.com and redirects to Firefox plugin that in description mentions already known ilovevitaly.