### PR TITLE
Adding traffic2cash.xyz

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -287,6 +287,7 @@ tomck.com
 top1-seo-service.com
 toyota.7zap.com
 traffic2cash.org
+traffic2cash.xyz
 traffic2money.com
 trafficmonetize.org
 trafficmonetizer.org


### PR DESCRIPTION
New today, 92% of traffic on one website, 100% bounce rate. Website offer dubious money making scheme, registered on the 10 dec 2015.