### PR TITLE
Add uptime.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -304,6 +304,7 @@ trafficmonetize.org
 trafficmonetizer.org
 trion.od.ua
 uasb.ru
+uptime.com
 uptimechecker.com
 uzungil.com
 video--production.com


### PR DESCRIPTION
Hit 3 diff GA accounts of mine starting on March 1st.

A lot of other complaints online about it
https://www.ohow.co/what-is-uptime-com-referral-in-google-analytics/
http://botcrawl.com/block-uptime-com-referral-in-google-analytics/