### PR TITLE
Add wordpresscore.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -324,6 +324,7 @@ websites-reviews.com
 websocial.me
 wmasterlead.com
 wordpress-crew.net
+wordpresscore.com
 ykecwqlixx.ru
 youporn-forum.ga
 youporn-forum.uni.me


### PR DESCRIPTION
Started showing up in GA March 20th.

Shows up as : wordpresscore.com

Other complaints about this domain:
https://blog.sucuri.net/2016/03/when-wordpress-plugin-goes-bad.html
http://betanews.com/2016/03/05/wordpress-plug-password-backdoor/
http://www.securityweek.com/backdoor-wordpress-plugin-steals-admin-credentials
http://news.softpedia.com/news/popular-wordpress-plugin-comes-with-a-backdoor-steals-site-admin-credentials-501383.shtml
https://www.youtube.com/watch?v=7hnJ1i9bIFo

Should be added and blocked ASAP to prevent malicious hacks/activity.