### PR TITLE
Adding free-video-tool.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -128,6 +128,7 @@ free-share-buttons.com
 free-social-buttons.com
 free-social-buttons.xyz
 free-traffic.xyz
+free-video-tool.com
 freewhatsappload.com
 fsalas.com
 generalporn.org


### PR DESCRIPTION
This is just another domain of semalt.media which are known for referrer spam