### PR TITLE
Add social-button.xyz

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -288,6 +288,7 @@ snip.to
 snip.tw
 soaksoak.ru
 social-buttons.com
+social-button.xyz
 social-widget.xyz
 socialseet.ru
 sohoindia.net


### PR DESCRIPTION
Started showing up in GA on April 11th.

Domain redirects to http://sharebutton.to/