### PR TITLE
Add hdmoviecams.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -148,6 +148,7 @@ googlsucks.com
 guardlink.org
 handicapvantoday.com
 hdmoviecamera.net
+hdmoviecams.com
 hongfanji.com
 hosting-tracker.com
 howopen.ru


### PR DESCRIPTION
Started showing up in GA April 25th.

Shows up as "website-stealer-warning-alert.hdmoviecams.com"