### PR TITLE
Add free-social-buttons7.xyz

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -130,6 +130,7 @@ free-floating-buttons.com
 free-share-buttons.com
 free-social-buttons.com
 free-social-buttons.xyz
+free-social-buttons7.xyz
 free-traffic.xyz
 free-video-tool.com
 freewhatsappload.com


### PR DESCRIPTION
Adding `free-social-buttons7.xyz`, a domain spamming several GA accounts I manage.

Confirmed in, and closes #300.