### PR TITLE
Add ghostvisitor.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -143,6 +143,7 @@ get-your-social-buttons.info
 getrichquick.ml
 getrichquickly.info
 ghazel.ru
+ghostvisitor.com
 girlporn.ru
 gkvector.ru
 glavprofit.ru


### PR DESCRIPTION
Showing up in GA as forum.topic76161710.ghostvisitor.com and misc. other sub domains in the same format but with different numbers added.