### PR TITLE
Add cookie-law-enforcement-ii.xyz

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -83,6 +83,7 @@ codysbbq.com
 conciergegroup.org
 connectikastudio.com
 cookie-law-enforcement-dd.xyz
+cookie-law-enforcement-ii.xyz
 copyrightclaims.org
 covadhosting.biz
 cubook.supernew.org


### PR DESCRIPTION
Another of the 'cookie law' spam domains showing up in referrer spam honeypot.
