### PR TITLE
Added fix-website-errors.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -153,6 +153,7 @@ event-tracking.com
 fast-wordpress-start.com
 fbdownloader.com
 floating-share-buttons.com
+fix-website-errors.com
 for-your.website
 forex-procto.ru
 forsex.info


### PR DESCRIPTION
Seems that GA catches most spammers currently but this one got through. Around 60 visits to 3 of our managed websites yesterday (10th June) all with 100% bounce rate. Domain itself redirects to the kings of referrer spam semalt.com - need I say any more?