### PR TITLE
Add site-auditor.online

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -341,6 +341,7 @@ sharebutton.to
 shop.xz618.com
 sibecoprom.ru
 simple-share-buttons.com
+site-auditor.online
 site5.com
 siteripz.net
 sitevaluation.org


### PR DESCRIPTION
New spammer showed up on 16th June, then created 81 fake referrals in 3 days. Domain points to known spammer ranksonic.com.