### PR TITLE
Add law-check-two.xyz

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -232,6 +232,7 @@ kino-key.info
 kinopolet.net
 knigonosha.net
 konkursov.net
+law-check-two.xyz
 law-enforcement-ee.xyz
 law-enforcement-bot-ff.xyz
 law-enforcement-check-three.xyz


### PR DESCRIPTION
Caused 80%+ of traffic on 3 websites. The seem to be trying a new trick by putting a unique code in the sub-domain, eg. 50455867.law-check-two.xyz to track who clicks on the link. Multiple redirects and intermediate websites try and give the impression that they are getting information from genuine governmental websites. Clearly a scam.