### PR TITLE
Add top10-way.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -426,6 +426,7 @@ tedxrj.com
 theguardlan.com
 tomck.com
 top1-seo-service.com
+top10-way.com
 topquality.cf
 topseoservices.co
 traffic-cash.xyz


### PR DESCRIPTION
New redirect domain to semalt (common known spammer). Appeared in my referral logs with usual query string containing my domain.