### PR TITLE
Add aviav.ru.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -49,7 +49,7 @@ arkkivoltti.net
 artparquet.ru
 aruplighting.com
 autovideobroadcast.com
-aviav.ru
+aviav.ru.com
 aviva-limoux.com
 azartclub.org
 azbukafree.com

--- a/spammers.txt
+++ b/spammers.txt
@@ -49,7 +49,7 @@ arkkivoltti.net
 artparquet.ru
 aruplighting.com
 autovideobroadcast.com
-aviav.co
+aviav.eu
 aviva-limoux.com
 azartclub.org
 azbukafree.com

--- a/spammers.txt
+++ b/spammers.txt
@@ -43,7 +43,6 @@ analytics-ads.xyz
 anapa-inns.ru
 android-style.com
 anticrawler.org
-apxeo.info
 arendakvartir.kz
 arendovalka.xyz
 arkkivoltti.net

--- a/spammers.txt
+++ b/spammers.txt
@@ -50,6 +50,7 @@ arkkivoltti.net
 artparquet.ru
 aruplighting.com
 autovideobroadcast.com
+aviav.co
 aviva-limoux.com
 azartclub.org
 azbukafree.com

--- a/spammers.txt
+++ b/spammers.txt
@@ -49,7 +49,7 @@ arkkivoltti.net
 artparquet.ru
 aruplighting.com
 autovideobroadcast.com
-aviav.org
+aviav.ru
 aviva-limoux.com
 azartclub.org
 azbukafree.com

--- a/spammers.txt
+++ b/spammers.txt
@@ -43,6 +43,7 @@ analytics-ads.xyz
 anapa-inns.ru
 android-style.com
 anticrawler.org
+apxeo.info
 arendakvartir.kz
 arendovalka.xyz
 arkkivoltti.net

--- a/spammers.txt
+++ b/spammers.txt
@@ -49,7 +49,7 @@ arkkivoltti.net
 artparquet.ru
 aruplighting.com
 autovideobroadcast.com
-aviav.eu
+aviav.org
 aviva-limoux.com
 azartclub.org
 azbukafree.com


### PR DESCRIPTION
Referrer spam found in my logs

193.124.131.27 - - [30/Oct/2016:12:50:56 -0400] "HEAD / HTTP/1.1" 200 - "http:// aviav. ru.com" "Mozilla/4.0 (compatible; MSIE4.00; Windows 2003)"
193.124.131.27 - - [30/Oct/2016:16:47:35 -0400] "HEAD / HTTP/1.1" 200 - "http:// aviav. ru.com" "Mozilla/6.0 (compatible; MSIE7.00; Windows 2007)"
193.124.131.27 - - [30/Oct/2016:20:41:56 -0400] "HEAD / HTTP/1.1" 200 - "http:// aviav. ru.com" "Mozilla/7.0 (compatible; MSIE6.00; Windows 2008)"
193.124.131.27 - - [31/Oct/2016:00:32:39 -0400] "HEAD / HTTP/1.1" 200 - "http:// aviav. ru.com" "Mozilla/7.0 (compatible; MSIE2.00; Windows 2007)"