### PR TITLE
Add aviav.info

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -49,7 +49,7 @@ arkkivoltti.net
 artparquet.ru
 aruplighting.com
 autovideobroadcast.com
-aviav.ru
+aviav.ru.com
 aviva-limoux.com
 azartclub.org
 azbukafree.com

--- a/spammers.txt
+++ b/spammers.txt
@@ -49,7 +49,6 @@ arkkivoltti.net
 artparquet.ru
 aruplighting.com
 autovideobroadcast.com
-aviav.ru.com
 aviva-limoux.com
 azartclub.org
 azbukafree.com
@@ -96,6 +95,7 @@ cardiosport.com.ua
 cartechnic.ru
 cenokos.ru
 cenoval.ru
+centrdebut.ru
 cezartabac.ro
 chcu.net
 chinese-amezon.com

--- a/spammers.txt
+++ b/spammers.txt
@@ -49,7 +49,7 @@ arkkivoltti.net
 artparquet.ru
 aruplighting.com
 autovideobroadcast.com
-aviav.co
+aviav.eu
 aviva-limoux.com
 azartclub.org
 azbukafree.com

--- a/spammers.txt
+++ b/spammers.txt
@@ -43,7 +43,6 @@ analytics-ads.xyz
 anapa-inns.ru
 android-style.com
 anticrawler.org
-apxeo.info
 arendakvartir.kz
 arendovalka.xyz
 arkkivoltti.net

--- a/spammers.txt
+++ b/spammers.txt
@@ -50,6 +50,7 @@ arkkivoltti.net
 artparquet.ru
 aruplighting.com
 autovideobroadcast.com
+aviav.co
 aviva-limoux.com
 azartclub.org
 azbukafree.com

--- a/spammers.txt
+++ b/spammers.txt
@@ -49,7 +49,7 @@ arkkivoltti.net
 artparquet.ru
 aruplighting.com
 autovideobroadcast.com
-aviav.org
+aviav.ru
 aviva-limoux.com
 azartclub.org
 azbukafree.com

--- a/spammers.txt
+++ b/spammers.txt
@@ -43,6 +43,7 @@ analytics-ads.xyz
 anapa-inns.ru
 android-style.com
 anticrawler.org
+apxeo.info
 arendakvartir.kz
 arendovalka.xyz
 arkkivoltti.net

--- a/spammers.txt
+++ b/spammers.txt
@@ -49,7 +49,7 @@ arkkivoltti.net
 artparquet.ru
 aruplighting.com
 autovideobroadcast.com
-aviav.eu
+aviav.org
 aviva-limoux.com
 azartclub.org
 azbukafree.com

--- a/spammers.txt
+++ b/spammers.txt
@@ -49,6 +49,7 @@ arkkivoltti.net
 artparquet.ru
 aruplighting.com
 autovideobroadcast.com
+aviav.info
 aviva-limoux.com
 azartclub.org
 azbukafree.com
@@ -95,7 +96,6 @@ cardiosport.com.ua
 cartechnic.ru
 cenokos.ru
 cenoval.ru
-centrdebut.ru
 cezartabac.ro
 chcu.net
 chinese-amezon.com


### PR DESCRIPTION
Referrer spam found in my logs

185.158.113.14 - - [30/Oct/2016:20:33:20 -0400] "HEAD / HTTP/1.1" 200 - "http:// aviav. info" "Mozilla/4.0 (compatible; MSIE3.00; Windows 2005)"
185.158.113.14 - - [31/Oct/2016:02:32:59 -0400] "HEAD / HTTP/1.1" 200 - "http:// aviav. info" "Mozilla/4.0 (compatible; MSIE4.00; Windows 2004)"