### PR TITLE
Add electricwheelchairsarea.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -49,7 +49,7 @@ arkkivoltti.net
 artparquet.ru
 aruplighting.com
 autovideobroadcast.com
-aviav.ru
+aviav.ru.com
 aviva-limoux.com
 azartclub.org
 azbukafree.com

--- a/spammers.txt
+++ b/spammers.txt
@@ -49,7 +49,6 @@ arkkivoltti.net
 artparquet.ru
 aruplighting.com
 autovideobroadcast.com
-aviav.ru.com
 aviva-limoux.com
 azartclub.org
 azbukafree.com
@@ -96,6 +95,7 @@ cardiosport.com.ua
 cartechnic.ru
 cenokos.ru
 cenoval.ru
+centrdebut.ru
 cezartabac.ro
 chcu.net
 chinese-amezon.com

--- a/spammers.txt
+++ b/spammers.txt
@@ -49,7 +49,7 @@ arkkivoltti.net
 artparquet.ru
 aruplighting.com
 autovideobroadcast.com
-aviav.co
+aviav.eu
 aviva-limoux.com
 azartclub.org
 azbukafree.com

--- a/spammers.txt
+++ b/spammers.txt
@@ -49,7 +49,6 @@ arkkivoltti.net
 artparquet.ru
 aruplighting.com
 autovideobroadcast.com
-aviav.info
 aviva-limoux.com
 azartclub.org
 azbukafree.com
@@ -181,6 +180,7 @@ edakgfvwql.ru
 egovaleo.it
 ekatalog.xyz
 ekto.ee
+electricwheelchairsarea.com
 elmifarhangi.com
 erot.co
 escort-russian.com

--- a/spammers.txt
+++ b/spammers.txt
@@ -43,7 +43,6 @@ analytics-ads.xyz
 anapa-inns.ru
 android-style.com
 anticrawler.org
-apxeo.info
 arendakvartir.kz
 arendovalka.xyz
 arkkivoltti.net

--- a/spammers.txt
+++ b/spammers.txt
@@ -50,6 +50,7 @@ arkkivoltti.net
 artparquet.ru
 aruplighting.com
 autovideobroadcast.com
+aviav.co
 aviva-limoux.com
 azartclub.org
 azbukafree.com

--- a/spammers.txt
+++ b/spammers.txt
@@ -49,7 +49,7 @@ arkkivoltti.net
 artparquet.ru
 aruplighting.com
 autovideobroadcast.com
-aviav.org
+aviav.ru
 aviva-limoux.com
 azartclub.org
 azbukafree.com

--- a/spammers.txt
+++ b/spammers.txt
@@ -43,6 +43,7 @@ analytics-ads.xyz
 anapa-inns.ru
 android-style.com
 anticrawler.org
+apxeo.info
 arendakvartir.kz
 arendovalka.xyz
 arkkivoltti.net

--- a/spammers.txt
+++ b/spammers.txt
@@ -49,7 +49,7 @@ arkkivoltti.net
 artparquet.ru
 aruplighting.com
 autovideobroadcast.com
-aviav.eu
+aviav.org
 aviva-limoux.com
 azartclub.org
 azbukafree.com

--- a/spammers.txt
+++ b/spammers.txt
@@ -49,6 +49,7 @@ arkkivoltti.net
 artparquet.ru
 aruplighting.com
 autovideobroadcast.com
+aviav.info
 aviva-limoux.com
 azartclub.org
 azbukafree.com
@@ -95,7 +96,6 @@ cardiosport.com.ua
 cartechnic.ru
 cenokos.ru
 cenoval.ru
-centrdebut.ru
 cezartabac.ro
 chcu.net
 chinese-amezon.com


### PR DESCRIPTION
Referrer spam found in my logs

134.249.74.95 - - [12/Nov/2016:18:14:40 +0100] "GET /*/ HTTP/1.0" 301 235 "http:// electricwheelchairsarea. com/" "Mozilla/4.0 (compatible; MSIE 6.0; Windows XP)"
134.249.74.95 - - [12/Nov/2016:18:14:41 +0100] "GET /*/ HTTP/1.0" 301 235 "http:// electricwheelchairsarea. com/" "Mozilla/4.0 (compatible; MSIE 6.0; Windows XP)"
134.249.74.95 - - [12/Nov/2016:18:14:41 +0100] "GET /*/ HTTP/1.0" 301 235 "http:// electricwheelchairsarea. com/" "Mozilla/4.0 (compatible; MSIE 6.0; Windows XP)"