### PR TITLE
Update spammers text with new domains

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -391,9 +391,11 @@ sanjosestartups.com
 santasgift.ml
 savetubevideo.com
 savetubevideo.info
+scansafe.net
 screentoolkit.com
 scripted.com
 search-error.com
+searchencrypt.com
 semalt.com
 semaltmedia.com
 seo-2-0.com


### PR DESCRIPTION
added searchencrypt.com and scansafe.net to the blacklist