### PR TITLE
Add autoseo-traffic.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -51,6 +51,7 @@ arendovalka.xyz
 arkkivoltti.net
 artparquet.ru
 aruplighting.com
+autoseo-traffic.com
 autovideobroadcast.com
 aviva-limoux.com
 azartclub.org


### PR DESCRIPTION
new referrer spam URL showing up in GA starting July 2 2017.