### PR TITLE
Add xkaz.org and all subdomains

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -508,6 +508,7 @@ woman-orgasm.ru
 wordpress-crew.net
 wordpresscore.com
 works.if.ua
+xkaz.org
 ykecwqlixx.ru
 youporn-forum.ga
 youporn-forum.uni.me


### PR DESCRIPTION
The following referrers were found in logs:
shymkent.xkaz.org
taraz.xkaz.org
Shymkent and Taraz are cities in Kazakhstan. The root site has links to multiple sites following the same pattern, which seem to all be porn sites.