### PR TITLE
Add zrus.org and all subdomains

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -515,6 +515,7 @@ youporn-ru.com
 yourserverisdown.com
 zastroyka.org
 zoominfo.com
+zrus.org
 zvetki.ru
 xn--c1acygb.xn--p1ai
 xn----8sbhefaln6acifdaon5c6f4axh.xn--p1ai


### PR DESCRIPTION
Follows same pattern as https://github.com/piwik/referrer-spam-blacklist/pull/614, except with Russia instead of Kazakhstan.