### PR TITLE
Add shoppingmiracles.co.uk

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -515,6 +515,7 @@ youporn-ru.com
 yourserverisdown.com
 zastroyka.org
 zoominfo.com
+zrus.org
 zvetki.ru
 xn--c1acygb.xn--p1ai
 xn----8sbhefaln6acifdaon5c6f4axh.xn--p1ai

--- a/spammers.txt
+++ b/spammers.txt
@@ -418,6 +418,7 @@ sharebutton.io
 sharebutton.net
 sharebutton.to
 shop.xz618.com
+shoppingmiracles.co.uk
 sibecoprom.ru
 simple-share-buttons.com
 site-auditor.online

--- a/spammers.txt
+++ b/spammers.txt
@@ -516,7 +516,6 @@ youporn-ru.com
 yourserverisdown.com
 zastroyka.org
 zoominfo.com
-zrus.org
 zvetki.ru
 xn--c1acygb.xn--p1ai
 xn----8sbhefaln6acifdaon5c6f4axh.xn--p1ai


### PR DESCRIPTION
Found in WP Statistics logs. Blog about shopping for pretty much anything. Seems to be a legitimate site a first glance, but all of their amazon links have their own referral link. They are probably trying to promote their own site for profit through referral spam.