### PR TITLE
Add adanih.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -22,6 +22,7 @@ abcdeg.xyz
 abclauncher.com
 acads.net
 acunetix-referrer.com
+adanih.com
 adcash.com
 adf.ly
 adspart.com


### PR DESCRIPTION
adanih.com appears to be a site for free HD wallpapers.  However the full URL they spammed links to porn which includes child pornography.