### PR TITLE
Added homeafrikalike.tk

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -255,6 +255,7 @@ havepussy.com
 hawaiisurf.com
 hdmoviecamera.net
 hdmoviecams.com
+homeafrikalike.tk
 hongfanji.com
 hosting-tracker.com
 housediz.com


### PR DESCRIPTION
This "new-machina.html" referrer spammer hit my logs with 8 different domains.

Googling "new-machina.html" shows that a number of the results are obvious spamdexing sites.  Some are just replicated sites, using the same page layout/theme and many of the same images.
