### PR TITLE
Added freewlan.info

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -226,6 +226,7 @@ free-social-buttons.xyz
 free-social-buttons7.xyz
 free-traffic.xyz
 free-video-tool.com
+freewlan.info
 freenode.info
 freewhatsappload.com
 fsalas.com

--- a/spammers.txt
+++ b/spammers.txt
@@ -226,9 +226,9 @@ free-social-buttons.xyz
 free-social-buttons7.xyz
 free-traffic.xyz
 free-video-tool.com
-freewlan.info
 freenode.info
 freewhatsappload.com
+freewlan.info
 fsalas.com
 gearcraft.us
 gearsadspromo.club


### PR DESCRIPTION
Referrer originating from a completely unrelated site.  Googling "tora-home-design-reviews.html" used in the referrer URL shows a number of replicated spamdexing sites with the same page layout/theme, same awkward English text that sounds like a bad machine translation, as the site on freewlan.info.