### PR TITLE
Added animalphotos.xyz

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -48,6 +48,7 @@ anal-acrobats.hol.es
 analytics-ads.xyz
 anapa-inns.ru
 android-style.com
+animalphotos.xyz
 anticrawler.org
 arendakvartir.kz
 arendovalka.xyz


### PR DESCRIPTION
Spamdexing site.  The referrer spam URL links to a page with illustrated child porn.