### PR TITLE
Added seocheckupx.com to the list

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -434,6 +434,7 @@ seo-2-0.com
 seo-platform.com
 seo-smm.kz
 seoanalyses.com
+seocheckupx.com
 seoexperimenty.ru
 seojokes.net
 seopub.net


### PR DESCRIPTION
"seocheckupx" referral appeared more than 30 times in a week on a website that usually has only 10-15 visits in the same timespan. It also uses the usual process of referral spammers, such as low number of pages visited and geographical origins essentially linked to Brazil / South America. The domain name itself is a clue, actually...