### PR TITLE
Added copyrightinstitute.org

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -159,6 +159,7 @@ cookie-law-enforcement-xx.xyz
 cookie-law-enforcement-yy.xyz
 cookie-law-enforcement-zz.xyz
 copyrightclaims.org
+copyrightinstitute.org
 covadhosting.biz
 cubook.supernew.org
 customsua.com.ua


### PR DESCRIPTION
complaint109505605.copyrightinstitute.org appeared in my Analytics.
It seems to be pointing to a Firefox add-on.